### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,12 +1,12 @@
 TEA5767	KEYWORD1
 
-isSearchMode KEYWORD2
-signalQuality KEYWORD2
-readFrequency KEYWORD2
-setFrequency KEYWORD2
-nextStation KEYWORD2
-PreviousStation KEYWORD2
-nextFrequency KEYWORD2
-previousFrequency KEYWORD2
-isStereo KEYWORD2
-begin KEYWORD2
+isSearchMode	KEYWORD2
+signalQuality	KEYWORD2
+readFrequency	KEYWORD2
+setFrequency	KEYWORD2
+nextStation	KEYWORD2
+PreviousStation	KEYWORD2
+nextFrequency	KEYWORD2
+previousFrequency	KEYWORD2
+isStereo	KEYWORD2
+begin	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords